### PR TITLE
chore: drop useless test

### DIFF
--- a/test/hello.test.ts
+++ b/test/hello.test.ts
@@ -1,5 +1,0 @@
-describe('Dummy', () => {
-  it('tests useless equality', () => {
-    expect(1).toBe(1);
-  });
-});


### PR DESCRIPTION
This test existed only to have jest pass when there were no tests... It's no longer needed now